### PR TITLE
Strip special characters from text input.

### DIFF
--- a/app/assets/_coffee/anchors.coffee
+++ b/app/assets/_coffee/anchors.coffee
@@ -26,7 +26,8 @@ class CS.Anchors
 
           # Refine it so it makes a good ID. Makes all lowercase and hyphen separated.
           # Ex. Hello World > hello-world
-          tidyText = roughText.replace(/\s+/g, "-").toLowerCase()
+          stripSpecial = roughText.replace(/[^\s\w]+/g, "").toLowerCase()
+          tidyText = stripSpecial.replace(/\s+/g, "-").toLowerCase()
 
           # Assign it to our element.
           # Currently the setAttribute element is only supported in IE9 and above.


### PR DESCRIPTION
Fixes #16.

@dcalhoun, let me know if this is what you were looking for.

If you changed the H2 header title to:

```
## He<>|:-ader Tw<>|:-o....\+*?[^]$(){}=!?
```

You should get an id of `header-two` and href of `#header-two`
